### PR TITLE
PartUtility: CreateOrUpdatePart for Function3D

### DIFF
--- a/Suplanus.Sepla/Helper/PartUtility.cs
+++ b/Suplanus.Sepla/Helper/PartUtility.cs
@@ -71,7 +71,7 @@ namespace Suplanus.Sepla.Helper
       else
       {
         // Check if pro panel, because there is no update possible
-        bool isProPanel = articleReference.ParentObject is Component;
+        bool isProPanel = articleReference.ParentObject is Function3D;
 
         string partNrTemp = partNr;
         if (!isProPanel)


### PR DESCRIPTION
If the parent object of the articleReference is of type Function3D, the check of `isProPanel` results in `false`. This causes a null reference during the creation of the function template.