### PR TITLE
TargetFramework 4.7.2 (EPLAN 2.9)

### DIFF
--- a/Suplanus.Example.EplAddIn.CallOfflineApplication/Suplanus.Example.EplAddIn.Preview.csproj
+++ b/Suplanus.Example.EplAddIn.CallOfflineApplication/Suplanus.Example.EplAddIn.Preview.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Suplanus.Example.EplAddIn.Preview</RootNamespace>
     <AssemblyName>Suplanus.Example.EplAddIn.Preview</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -34,8 +34,12 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Eplan.EplApi.AFu, Version=1.0.0.0, Culture=neutral, PublicKeyToken=57aaa27e22f7b107, processorArchitecture=AMD64" />
-    <Reference Include="Eplan.EplApi.Baseu, Version=1.0.0.0, Culture=neutral, PublicKeyToken=57aaa27e22f7b107, processorArchitecture=x86" />
+    <Reference Include="Eplan.EplApi.AFu">
+      <HintPath>C:\Program Files\EPLAN\Platform\2.9.4\Bin\Eplan.EplApi.AFu.dll</HintPath>
+    </Reference>
+    <Reference Include="Eplan.EplApi.Baseu">
+      <HintPath>C:\Program Files\EPLAN\Platform\2.9.4\Bin\Eplan.EplApi.Baseu.dll</HintPath>
+    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />

--- a/Suplanus.Example.EplAddIn.ItemTypeExample/Suplanus.Example.EplAddIn.ItemTypeExample.csproj
+++ b/Suplanus.Example.EplAddIn.ItemTypeExample/Suplanus.Example.EplAddIn.ItemTypeExample.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{CEC2A842-8415-438E-AD73-3227F417CF8E}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>Suplanus.Example.EplAddIn.ItemTypeExample</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <ApplicationVersion>1.0.0.0</ApplicationVersion>
     <FileAlignment>512</FileAlignment>
     <RootNamespace>Suplanus.Example.EplAddIn.ItemTypeExample</RootNamespace>
@@ -36,7 +36,7 @@
     <Reference Include="Eplan.EplApi.MasterDatau, Version=1.0.0.0, Culture=neutral, PublicKeyToken=57aaa27e22f7b107, processorArchitecture=AMD64" />
     <Reference Include="Eplan.EplSDK.WPF.DBu, Version=1.0.0.0, Culture=neutral, PublicKeyToken=57aaa27e22f7b107, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Program Files\EPLAN\Platform\2.6.3\Bin\Eplan.EplSDK.WPF.DBu.dll</HintPath>
+      <HintPath>C:\Program Files\EPLAN\Platform\2.9.4\Bin\Eplan.EplSDK.WPF.DBu.dll</HintPath>
     </Reference>
     <Reference Include="Eplan.EplSDK.WPFu, Version=1.0.0.0, Culture=neutral, PublicKeyToken=57aaa27e22f7b107, processorArchitecture=AMD64" />
     <Reference Include="PresentationFramework" />

--- a/Suplanus.Example.EplAddIn.PartsManagementExtensionExample/Suplanus.Example.EplAddIn.PartsManagementExtensionExample.csproj
+++ b/Suplanus.Example.EplAddIn.PartsManagementExtensionExample/Suplanus.Example.EplAddIn.PartsManagementExtensionExample.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{869842AA-B514-43C0-8304-8F4A72C35D15}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>Suplanus.Example.EplAddIn.PartsManagementExtensionExample</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <ApplicationVersion>1.0.0.0</ApplicationVersion>
     <FileAlignment>512</FileAlignment>
     <RootNamespace>Suplanus.Example.EplAddIn.PartsManagementExtensionExample</RootNamespace>
@@ -36,7 +36,7 @@
     <Reference Include="Eplan.EplApi.MasterDatau, Version=1.0.0.0, Culture=neutral, PublicKeyToken=57aaa27e22f7b107, processorArchitecture=AMD64" />
     <Reference Include="Eplan.EplSDK.WPF.DBu, Version=1.0.0.0, Culture=neutral, PublicKeyToken=57aaa27e22f7b107, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Program Files\EPLAN\Platform\2.6.3\Bin\Eplan.EplSDK.WPF.DBu.dll</HintPath>
+      <HintPath>C:\Program Files\EPLAN\Platform\2.9.4\Bin\Eplan.EplSDK.WPF.DBu.dll</HintPath>
     </Reference>
     <Reference Include="Eplan.EplSDK.WPFu, Version=1.0.0.0, Culture=neutral, PublicKeyToken=57aaa27e22f7b107, processorArchitecture=AMD64" />
     <Reference Include="PresentationFramework" />

--- a/Suplanus.Example.EplAddIn.SvgExport/Suplanus.Example.EplAddIn.SvgExport.csproj
+++ b/Suplanus.Example.EplAddIn.SvgExport/Suplanus.Example.EplAddIn.SvgExport.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Suplanus.Example.EplAddIn.SvgExport</RootNamespace>
     <AssemblyName>Suplanus.Example.EplAddIn.SvgExport</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
   </PropertyGroup>

--- a/Suplanus.Example.Preview/Suplanus.Example.Preview.csproj
+++ b/Suplanus.Example.Preview/Suplanus.Example.Preview.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Suplanus.Example.Preview</RootNamespace>
     <AssemblyName>Suplanus.Example.Preview</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/Suplanus.Sepla/Suplanus.Sepla.csproj
+++ b/Suplanus.Sepla/Suplanus.Sepla.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Suplanus.Sepla</RootNamespace>
     <AssemblyName>Suplanus.Sepla</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
@@ -212,81 +212,81 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Eplan.EplApi.AFu, Version=1.0.0.0, Culture=neutral, PublicKeyToken=57aaa27e22f7b107, processorArchitecture=AMD64">
-      <HintPath>C:\Program Files\EPLAN\Platform\2.7.3\Bin\Eplan.EplApi.AFu.dll</HintPath>
+      <HintPath>C:\Program Files\EPLAN\Platform\2.9.4\Bin\Eplan.EplApi.AFu.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="Eplan.EplApi.Baseu, Version=1.0.0.0, Culture=neutral, PublicKeyToken=57aaa27e22f7b107, processorArchitecture=AMD64">
-      <HintPath>C:\Program Files\EPLAN\Platform\2.7.3\Bin\Eplan.EplApi.Baseu.dll</HintPath>
+      <HintPath>C:\Program Files\EPLAN\Platform\2.9.4\Bin\Eplan.EplApi.Baseu.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="Eplan.EplApi.DataModelu, Version=1.0.0.0, Culture=neutral, PublicKeyToken=57aaa27e22f7b107, processorArchitecture=AMD64">
-      <HintPath>C:\Program Files\EPLAN\Platform\2.7.3\Bin\Eplan.EplApi.DataModelu.dll</HintPath>
+      <HintPath>C:\Program Files\EPLAN\Platform\2.9.4\Bin\Eplan.EplApi.DataModelu.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="Eplan.EplApi.EServicesu, Version=1.0.0.0, Culture=neutral, PublicKeyToken=57aaa27e22f7b107, processorArchitecture=AMD64">
-      <HintPath>C:\Program Files\EPLAN\Platform\2.7.3\Bin\Eplan.EplApi.EServicesu.dll</HintPath>
+      <HintPath>C:\Program Files\EPLAN\Platform\2.9.4\Bin\Eplan.EplApi.EServicesu.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="Eplan.EplApi.Guiu, Version=1.0.0.0, Culture=neutral, PublicKeyToken=57aaa27e22f7b107, processorArchitecture=AMD64">
-      <HintPath>C:\Program Files\EPLAN\Platform\2.7.3\Bin\Eplan.EplApi.Guiu.dll</HintPath>
+      <HintPath>C:\Program Files\EPLAN\Platform\2.9.4\Bin\Eplan.EplApi.Guiu.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="Eplan.EplApi.HEServicesu, Version=1.0.0.0, Culture=neutral, PublicKeyToken=57aaa27e22f7b107, processorArchitecture=AMD64">
-      <HintPath>C:\Program Files\EPLAN\Platform\2.7.3\Bin\Eplan.EplApi.HEServicesu.dll</HintPath>
+      <HintPath>C:\Program Files\EPLAN\Platform\2.9.4\Bin\Eplan.EplApi.HEServicesu.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="Eplan.EplApi.MasterDatau, Version=1.0.0.0, Culture=neutral, PublicKeyToken=57aaa27e22f7b107, processorArchitecture=AMD64">
-      <HintPath>C:\Program Files\EPLAN\Platform\2.7.3\Bin\Eplan.EplApi.MasterDatau.dll</HintPath>
+      <HintPath>C:\Program Files\EPLAN\Platform\2.9.4\Bin\Eplan.EplApi.MasterDatau.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="Eplan.EplApi.RecorderToolsu, Version=1.0.0.0, Culture=neutral, PublicKeyToken=57aaa27e22f7b107, processorArchitecture=AMD64">
-      <HintPath>C:\Program Files\EPLAN\Platform\2.7.3\Bin\Eplan.EplApi.RecorderToolsu.dll</HintPath>
+      <HintPath>C:\Program Files\EPLAN\Platform\2.9.4\Bin\Eplan.EplApi.RecorderToolsu.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="Eplan.EplApi.RemoteClientu, Version=1.0.0.0, Culture=neutral, PublicKeyToken=57aaa27e22f7b107, processorArchitecture=MSIL">
-      <HintPath>C:\Program Files\EPLAN\Platform\2.7.3\Bin\Eplan.EplApi.RemoteClientu.dll</HintPath>
+      <HintPath>C:\Program Files\EPLAN\Platform\2.9.4\Bin\Eplan.EplApi.RemoteClientu.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="Eplan.EplApi.Remotingu, Version=1.0.0.0, Culture=neutral, PublicKeyToken=57aaa27e22f7b107, processorArchitecture=MSIL">
-      <HintPath>C:\Program Files\EPLAN\Platform\2.7.3\Bin\Eplan.EplApi.Remotingu.dll</HintPath>
+      <HintPath>C:\Program Files\EPLAN\Platform\2.9.4\Bin\Eplan.EplApi.Remotingu.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="Eplan.EplApi.Simulationu, Version=1.0.0.0, Culture=neutral, PublicKeyToken=57aaa27e22f7b107, processorArchitecture=AMD64">
-      <HintPath>C:\Program Files\EPLAN\Platform\2.7.3\Bin\Eplan.EplApi.Simulationu.dll</HintPath>
+      <HintPath>C:\Program Files\EPLAN\Platform\2.9.4\Bin\Eplan.EplApi.Simulationu.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="Eplan.EplApi.Starteru, Version=1.0.0.0, Culture=neutral, PublicKeyToken=57aaa27e22f7b107, processorArchitecture=MSIL">
-      <HintPath>C:\Program Files\EPLAN\Platform\2.7.3\Bin\Eplan.EplApi.Starteru.dll</HintPath>
+      <HintPath>C:\Program Files\EPLAN\Platform\2.9.4\Bin\Eplan.EplApi.Starteru.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Eplan.EplApi.Systemu, Version=1.0.0.0, Culture=neutral, PublicKeyToken=57aaa27e22f7b107, processorArchitecture=AMD64">
-      <HintPath>C:\Program Files\EPLAN\Platform\2.7.3\Bin\Eplan.EplApi.Systemu.dll</HintPath>
+      <HintPath>C:\Program Files\EPLAN\Platform\2.9.4\Bin\Eplan.EplApi.Systemu.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="Eplan.EplApi.WebServiceu, Version=1.0.0.0, Culture=neutral, PublicKeyToken=ecea1219c93267ce, processorArchitecture=AMD64">
-      <HintPath>C:\Program Files\EPLAN\Platform\2.7.3\Bin\Eplan.EplApi.WebServiceu.dll</HintPath>
+      <HintPath>C:\Program Files\EPLAN\Platform\2.9.4\Bin\Eplan.EplApi.WebServiceu.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="Eplan.EplSDK.WebControlResu, Version=1.0.0.0, Culture=neutral, PublicKeyToken=57aaa27e22f7b107, processorArchitecture=MSIL">
-      <HintPath>C:\Program Files\EPLAN\Platform\2.7.3\Bin\Eplan.EplSDK.WebControlResu.dll</HintPath>
+      <HintPath>C:\Program Files\EPLAN\Platform\2.9.4\Bin\Eplan.EplSDK.WebControlResu.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
     <Reference Include="Eplan.EplSDK.WPFu, Version=1.0.0.0, Culture=neutral, PublicKeyToken=57aaa27e22f7b107, processorArchitecture=AMD64">
-      <HintPath>C:\Program Files\EPLAN\Platform\2.7.3\Bin\Eplan.EplSDK.WPFu.dll</HintPath>
+      <HintPath>C:\Program Files\EPLAN\Platform\2.9.4\Bin\Eplan.EplSDK.WPFu.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>


### PR DESCRIPTION
Example Projects are still missing hint paths for EPLAN assemblies.